### PR TITLE
Add new utility classes and update component layouts

### DIFF
--- a/public/assets/css/output.css
+++ b/public/assets/css/output.css
@@ -277,6 +277,9 @@
   .left-0 {
     left: calc(var(--spacing) * 0);
   }
+  .z-0 {
+    z-index: 0;
+  }
   .z-40 {
     z-index: 40;
   }
@@ -366,6 +369,9 @@
   }
   .table {
     display: table;
+  }
+  .h-1 {
+    height: calc(var(--spacing) * 1);
   }
   .h-1\.5 {
     height: calc(var(--spacing) * 1.5);
@@ -466,8 +472,14 @@
   .flex-1 {
     flex: 1;
   }
+  .flex-shrink {
+    flex-shrink: 1;
+  }
   .flex-shrink-0 {
     flex-shrink: 0;
+  }
+  .border-collapse {
+    border-collapse: collapse;
   }
   .origin-top-right {
     transform-origin: top right;
@@ -477,6 +489,9 @@
   }
   .cursor-pointer {
     cursor: pointer;
+  }
+  .resize {
+    resize: both;
   }
   .appearance-none {
     appearance: none;
@@ -768,6 +783,9 @@
   .px-6 {
     padding-inline: calc(var(--spacing) * 6);
   }
+  .py-0 {
+    padding-block: calc(var(--spacing) * 0);
+  }
   .py-0\.5 {
     padding-block: calc(var(--spacing) * 0.5);
   }
@@ -985,6 +1003,9 @@
   .italic {
     font-style: italic;
   }
+  .underline {
+    text-decoration-line: underline;
+  }
   .placeholder-gray-500 {
     &::placeholder {
       color: var(--color-gray-500);
@@ -1016,6 +1037,10 @@
   }
   .ring-black {
     --tw-ring-color: var(--color-black);
+  }
+  .outline {
+    outline-style: var(--tw-outline-style);
+    outline-width: 1px;
   }
   .transition {
     transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, visibility, content-visibility, overlay, pointer-events;
@@ -1343,6 +1368,11 @@
       margin-left: calc(var(--spacing) * 6);
     }
   }
+  .md\:block {
+    @media (width >= 48rem) {
+      display: block;
+    }
+  }
   .md\:flex {
     @media (width >= 48rem) {
       display: flex;
@@ -1567,6 +1597,11 @@
   inherits: false;
   initial-value: 0 0 #0000;
 }
+@property --tw-outline-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
     *, ::before, ::after, ::backdrop {
@@ -1596,6 +1631,7 @@
       --tw-ring-offset-width: 0px;
       --tw-ring-offset-color: #fff;
       --tw-ring-offset-shadow: 0 0 #0000;
+      --tw-outline-style: solid;
     }
   }
 }

--- a/src/app/components/base/client/dashboard/cartography/cartography.component.html
+++ b/src/app/components/base/client/dashboard/cartography/cartography.component.html
@@ -38,7 +38,7 @@
             </button>
           </div>
         </div>
-        <div class="relative rounded-lg overflow-hidden" style="height: 600px;">
+        <div class="relative rounded-lg overflow-hidden z-0" style="height: 600px;">
           <div id="map" style="height: 100%; width: 100%;"></div>
         </div>
       </div>

--- a/src/app/components/include/navbar/navbar.component.html
+++ b/src/app/components/include/navbar/navbar.component.html
@@ -89,8 +89,7 @@
             <i class="fas fa-bars"></i>
           </button>
 
-          <!-- Dans votre template, modifiez la partie recherche -->
-          <div class="ml-4 relative md:ml-6 z-50 w-full max-w-md">
+          <div class="ml-4 relative md:ml-6 z-50 w-full max-w-md hidden md:block">
             <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
               <i class="fas fa-search text-gray-400"></i>
             </div>
@@ -103,7 +102,6 @@
               type="search"
             >
 
-            <!-- Résultats de recherche -->
             <div *ngIf="showResults && searchResults.length > 0"
                  class="absolute z-[9999] mt-1 w-full bg-white shadow-lg rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto max-h-60"
                  style="position: fixed; width: inherit; max-width: inherit;">


### PR DESCRIPTION
Introduced several new utility classes in output.css, including z-0, h-1, flex-shrink, border-collapse, resize, py-0, underline, outline, and md:block. Updated cartography.component.html to add z-0 for proper stacking context. Modified navbar.component.html to hide the search bar on small screens and show it as a block on medium screens and above.