### PR TITLE
Update dashboard section descriptions and remove alerts link

### DIFF
--- a/src/app/components/base/client/dashboard/cartography/cartography.component.html
+++ b/src/app/components/base/client/dashboard/cartography/cartography.component.html
@@ -7,8 +7,9 @@
       <div class="flex justify-between items-center mb-6">
         <div>
           <h1 class="text-2xl font-bold text-gray-900">Cartographie COVID-19</h1>
-          <p class="mt-1 text-sm text-gray-500">Dernière mise à jour : <span
-            id="last-updated">26 juin 2023, 14:30</span></p>
+          <p class="mt-1 text-sm text-gray-500 hidden md:block">
+            Visualisation interactive de la propagation du COVID-19 à l’échelle mondiale, pays par pays.
+          </p>
         </div>
         <div class="flex space-x-3">
           <button (click)="dataService.export()"

--- a/src/app/components/base/client/dashboard/dashboard.component.html
+++ b/src/app/components/base/client/dashboard/dashboard.component.html
@@ -8,8 +8,7 @@
       <div class="flex justify-between items-center mb-6">
         <div>
           <h1 class="text-2xl font-bold text-gray-900">Tableau de bord COVID-19</h1>
-          <p class="mt-1 text-sm text-gray-500">Dernière mise à jour: <span id="last-updated">26 juin 2023, 14:30</span>
-          </p>
+          <p class="mt-1 text-sm text-gray-500 hidden md:block">Suivi global de la pandémie de COVID-19 à travers des données actualisées et des visualisations interactives.</p>
         </div>
         <div class="flex space-x-3">
           <button (click)="dataService.export()"

--- a/src/app/components/base/client/dashboard/data/data.component.html
+++ b/src/app/components/base/client/dashboard/data/data.component.html
@@ -7,8 +7,8 @@
       <div class="flex justify-between items-center mb-6">
         <div>
           <h1 class="text-2xl font-bold text-gray-900">Données brutes</h1>
-          <p class="mt-1 text-sm text-gray-500">
-            Accédez aux données brutes COVID-19 par pays, date ou indicateur.
+          <p class="mt-1 text-sm text-gray-500 hidden md:block">
+            Accédez aux données brutes COVID-19 par pays.
           </p>
         </div>
         <div class="flex space-x-3">

--- a/src/app/components/base/client/dashboard/prediction/prediction.component.html
+++ b/src/app/components/base/client/dashboard/prediction/prediction.component.html
@@ -6,8 +6,7 @@
       <div class="flex justify-between items-center mb-6">
         <div>
           <h1 class="text-2xl font-bold text-gray-900">Prédictions IA</h1>
-          <p class="mt-1 text-sm text-gray-500">Dernière analyse : <span id="last-analyzed">15 mai 2025, 10:00</span>
-          </p>
+          <p class="mt-1 text-sm text-gray-500 hidden md:block">Analyse et visualisation des cas prédits par l'intelligence artificielle, pays par pays.</p>
         </div>
         <div class="flex space-x-3">
           <button (click)="dataService.export()"

--- a/src/app/components/include/client/sidebar/sidebar.component.html
+++ b/src/app/components/include/client/sidebar/sidebar.component.html
@@ -124,19 +124,6 @@
                class="fas fa-robot mr-3"></i>
             Prédictions IA
           </a>
-
-          <a
-            #rlaAlerts="routerLinkActive"
-            [routerLinkActiveOptions]="{ exact: true }"
-            class="group flex items-center px-3 py-2 text-sm font-medium rounded-md transition-all"
-            routerLink="/client/alerts"
-            routerLinkActive="active-menu-item"
-          >
-            <i [ngClass]="rlaAlerts.isActive ? 'text-blue-200' : 'text-gray-400 group-hover:text-gray-500'"
-               class="fas fa-bell mr-3"></i>
-            Alertes
-            <span class="notification-dot"></span>
-          </a>
         </div>
       </nav>
     </div>


### PR DESCRIPTION
Revised the descriptions in dashboard section headers for improved clarity and consistency, making them visible only on medium screens and above. Also removed the 'Alertes' navigation link from the client sidebar.